### PR TITLE
fix: Gradient Error

### DIFF
--- a/optimization_test.cpp
+++ b/optimization_test.cpp
@@ -11,7 +11,54 @@ TEST(JET, Plus) {
   auto gradient = c.Gradient();
   EXPECT_EQ(gradient(0), 1.0);
   EXPECT_EQ(gradient(1), 1.0);
+  Jet<2> d = a * a + b * b;
+  EXPECT_EQ(d.value(), 5.0);
+  EXPECT_EQ(d.Gradient()(0), 2.0);
+  EXPECT_EQ(d.Gradient()(1), 4.0);
 }
+TEST(JET, Sub) {
+  Jet<2> a(1.0, 0);
+  Jet<2> b(2.0, 1);
+
+  Jet<2> c = a - b;
+  auto gradient = c.Gradient();
+  EXPECT_EQ(gradient(0), 1.0);
+  EXPECT_EQ(gradient(1), -1.0);
+}
+
+TEST(JET, Multiple) {
+  Jet<2> a(1.0, 0);
+  Jet<2> b(2.0, 1);
+
+  Jet<2> c = a * b;
+  auto gradient = c.Gradient();
+  EXPECT_EQ(gradient(0), 2.0);
+  EXPECT_EQ(gradient(1), 1.0);
+}
+
+TEST(JET, Eigen_Map) {
+    std::vector<Jet<2>> input(2);
+    for(int i = 0; i < 2; i++) {
+        input[i] = Jet<2>(i + 1, i);
+    }
+    auto eigen = Eigen::Map<Eigen::Matrix<Jet<2>, 2, 1>>(&input[0]);
+    auto first_element = eigen(0);
+    auto second_element = eigen(1);
+    EXPECT_EQ(first_element.value(), 1.0);
+    EXPECT_EQ(second_element.value(), 2.0);
+    EXPECT_EQ(first_element.Gradient()(0), 1.0);
+    EXPECT_EQ(first_element.Gradient()(1), 0.0);
+    EXPECT_EQ(second_element.Gradient()(0), 0.0);
+    EXPECT_EQ(second_element.Gradient()(1), 1.0);
+
+    Eigen::Matrix<Jet<2>, 1, 1> result(eigen(0) * eigen(0) + eigen(1) * eigen(1));
+
+    EXPECT_EQ(result(0).value(),  5.0);
+    auto g = result(0).Gradient();
+    EXPECT_EQ(g(0), 2.0);
+    EXPECT_EQ(g(1), 4.0);
+}
+
 struct LinearFunctor {
   template <class T>
   bool operator()(T* input, T* residual) const {
@@ -75,11 +122,12 @@ TEST(LenearSyste, Gradient_CHECK) {
       return (A * x0 - b).dot(A * x0 - b);
     };
     auto computed_gradient_value = computed_gradient(x);
-    std::cout << "gradient : " << gradient << std::endl;
-    std::cout << "computed_gradient : " << computed_gradient_value << std::endl;
-    std::cout << "V : " << auto_diff(x) << std::endl;
-    std::cout << "Value : " << inference(x) << std::endl;
-    x = x - 0.001 * gradient.transpose();
+    //std::cout << "gradient : " << gradient << std::endl;
+    //std::cout << "computed_gradient : " << computed_gradient_value << std::endl;
+    //std::cout << "V : " << auto_diff(x) << std::endl;
+    //std::cout << "Value : " << inference(x) << std::endl;
+    x = x - 0.001 * computed_gradient_value;
+    //std::cout << "x : " << x.transpose() << std::endl;
   }
 }
 


### PR DESCRIPTION
std::vector::data() method and &std::vector::[] have a kind of difference as a arguement passed to Eigen::Map<>().

Replace all the std::vector::data() to the first element address in the vector passed to Eigen::Map<>() because it will cause Gradient computed error.